### PR TITLE
Bump custom_base, add some tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Base62.Mixfile do
   def application, do: []
 
   defp deps do
-    [{:custom_base, "~> 0.1.0"},
+    [{:custom_base, "~> 0.2.0"},
      {:ex_doc, only: :dev},
      {:earmark, only: :dev}]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -16,8 +16,8 @@ defmodule Base62.Mixfile do
 
   defp deps do
     [{:custom_base, "~> 0.2.0"},
-     {:ex_doc, only: :dev},
-     {:earmark, only: :dev}]
+     {:ex_doc, "~> 0.11", only: :dev},
+     {:earmark, "~> 0.2", only: :dev}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"custom_base": {:hex, :custom_base, "0.1.0"},
+%{"custom_base": {:hex, :custom_base, "0.2.0"},
   "earmark": {:hex, :earmark, "0.1.13"},
   "ex_doc": {:hex, :ex_doc, "0.7.1"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"custom_base": {:hex, :custom_base, "0.2.0"},
-  "earmark": {:hex, :earmark, "0.1.13"},
-  "ex_doc": {:hex, :ex_doc, "0.7.1"}}
+  "earmark": {:hex, :earmark, "0.2.1"},
+  "ex_doc": {:hex, :ex_doc, "0.11.4"}}

--- a/test/base62_test.exs
+++ b/test/base62_test.exs
@@ -69,6 +69,9 @@ defmodule Base62Test do
     assert encode(62) == "10"
     assert encode(100) == "1c"
     assert encode(124) == "20"
+    assert encode(4_815_162_342) == "5Frvgk"
+    assert encode(9_223_372_036_854_775_807) == "AzL8n0Y58m7"
+    assert encode(26_567_849_713_993_370_845_693_800_611_841) == "8zIcpbAKe8shBxXUtl"
   end
 
   test :decode do
@@ -137,7 +140,10 @@ defmodule Base62Test do
     assert decode("10") == { :ok, 62 }
     assert decode("1c") == { :ok, 100 }
     assert decode("20") == { :ok, 124 }
+    assert decode("5Frvgk") == { :ok, 4_815_162_342 }
     assert decode("zzzzzz") == { :ok, 56_800_235_583 }
+    assert decode("AzL8n0Y58m7") == { :ok, 9_223_372_036_854_775_807 }
+    assert decode("8zIcpbAKe8shBxXUtl") == { :ok, 26_567_849_713_993_370_845_693_800_611_841 }
   end
 
   test :decode! do
@@ -206,6 +212,9 @@ defmodule Base62Test do
     assert decode!("10") == 62
     assert decode!("1c") == 100
     assert decode!("20") == 124
+    assert decode!("5Frvgk") == 4_815_162_342
     assert decode!("zzzzzz") == 56_800_235_583
+    assert decode!("AzL8n0Y58m7") == 9_223_372_036_854_775_807
+    assert decode!("8zIcpbAKe8shBxXUtl") == 26_567_849_713_993_370_845_693_800_611_841
   end
 end


### PR DESCRIPTION
base62 is currently using a version of [custom_base](https://github.com/igas/custom_base/) tha causes  base62 encoding to be incorrect for large integer.

The bug in custom_base was fixed with https://github.com/igas/custom_base/pull/2

I've also some tests to prevent a regression in the future, as well as specifying versions for dev dependencies (this was causing some warning during compilation).